### PR TITLE
Clean up component

### DIFF
--- a/homie.py
+++ b/homie.py
@@ -281,6 +281,7 @@ class HomieNode(ChangeListener):
         self._prefix_topic = f'{base_topic}/{node_id}'
         self._on_component_ready = on_component_ready
         self._is_setup = False
+        self._state_property = STATE_UNKNOWN
 
         self._type = STATE_UNKNOWN
 
@@ -339,6 +340,24 @@ class HomieNode(ChangeListener):
     def get_property(self, property_name: str):
         """Return a specific Property for the node."""
         return self._properties[property_name]
+
+    @property
+    def state_property(self):
+        # Set the state property if it isn't already set. 
+        if self._state_property == STATE_UNKNOWN:
+            for property in self.properties:
+                property = self.properties[property]
+                if not "unit" in property.property_id and not "$" == property.property_id[0] and not "_" == property.property_id[0] and not "value" in property.property_id:
+                    if self._state_property != STATE_UNKNOWN:
+                        # TODO: Make this a more specific exception
+                        raise Exception('Could not detect which property should be used for state.')
+                    self._state_property = property
+
+        return self._state_property 
+
+    @state_property.setter
+    def set_state_proprety(self, value):
+        self._state_property = value
     
     @property
     def device(self):
@@ -367,8 +386,9 @@ class HomieProperty(ChangeListener):
 
     async def _async_update(self, topic: str, payload: str, qos: int):
         topic = topic.replace(self._prefix_topic, '')
-        
-        if topic == '': self._state = payload
+        if topic == '': 
+            self._state = payload
+
 
     @property
     def property_id(self):
@@ -414,4 +434,3 @@ class HomieProperty(ChangeListener):
     def format(self):
         """Return the Format for the Property."""
         return self._format
-    

--- a/homie.py
+++ b/homie.py
@@ -78,34 +78,53 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
         await mqtt.async_subscribe(hass, f'{discovery_prefix}/+/$homie', async_discover_message_received, qos)
 
     async def async_discover_message_received(topic: str, payload: str, msg_qos: int):
+        _LOGGER.debug(f"Discover Message Received")
         device_match = DISCOVER_DEVICE.match(topic)
+        _LOGGER.debug(f"device_match: {device_match}")
+        _LOGGER.debug(f"payload: {payload}")
+        _LOGGER.debug(f"HOMIE_SUPPORTED_VERSION: {HOMIE_SUPPORTED_VERSION}")
+
         if device_match and payload == HOMIE_SUPPORTED_VERSION:
+            _LOGGER.debug(f"Found a device.")
             device_base_topic = device_match.group('prefix_topic')
             device_id = device_match.group('device_id')
             if device_id not in _DEVICES:
+                _LOGGER.debug(f"It's not in devices.")
                 device = HomieDevice(device_base_topic, device_id, async_component_ready)
                 _DEVICES[device_id] = device
                 await device._async_setup(hass, qos)
     
     async def async_component_ready(component):
+        # Start by investigating why it seems like this component isn't being setup. 
+        # Should be setting up both.
+        # Could it have something to do with the fact that we're actually using Homie 2.0.1
+        _LOGGER.info(f"component_ready: " + str(type(component)))
         if type(component) is HomieDevice:
+            _LOGGER.debug(f"Found Homie Device!")
             await async_setup_device(component)
+            _LOGGER.info(f"Finished async_setup_device.")
         if type(component) is HomieNode:
+            _LOGGER.info(f"Found Homie Node!")
             await async_setup_node(component)
 
     async def async_setup_device(device: HomieDevice):
+        _LOGGER.debug(f"setup_device")
         pass
 
     async def async_setup_node(node: HomieNode):
+        _LOGGER.info(f"setup_node: node.type: " + str(node.type))
         def get_entity_name():
             return f"{node.device.device_id}_{node.node_id}"
         if node.type == 'sensor':
+            _LOGGER.info(f"setup_node: Sensor")
             await setup_device_node_as_platform(get_entity_name(), node, 'sensor')
         elif node.type == 'switch':
+            _LOGGER.info(f"setup_node: Switch")
             await setup_device_node_as_platform(get_entity_name(), node, 'switch')
 
 
     async def setup_device_node_as_platform(entity_name: str, node: HomieNode, platform: str):
+        _LOGGER.info(f"device node as platform")
         hass.data[KEY_HOMIE_ALREADY_DISCOVERED][entity_name] = node
         discovery_info = {KEY_HOMIE_ENTITY_NAME: entity_name}
         await async_load_platform(hass, platform, DOMAIN, discovery_info)
@@ -154,11 +173,17 @@ class HomieDevice(ChangeListener):
         
     async def _async_setup(self, hass:HomeAssistantType, qos: int):
         async def async_discover_message_received(topic: str, payload: str, msg_qos: int):
+            _LOGGER.info(f"Property Discover mesage received")
             node_match = DISCOVER_NODES.match(topic)
+            _LOGGER.info(f"topic: " + topic)
+            _LOGGER.info(f"payload: " + payload)
+            _LOGGER.info(f"node_match: " + str(node_match))
             if node_match:
+                _LOGGER.info(f"The node_mached.")
                 node_base_topic = node_match.group('prefix_topic')
                 node_id = node_match.group('node_id')
                 if node_id not in self._nodes:
+                    _LOGGER.info(f"Not in self.nodes.")
                     node = HomieNode(self, node_base_topic, node_id, self._on_component_ready)
                     self._nodes[node_id] = node
                     await node._async_setup(hass, qos, payload)
@@ -167,6 +192,7 @@ class HomieDevice(ChangeListener):
         await mqtt.async_subscribe(hass, f'{self._prefix_topic}/#', self._async_update, qos)
 
     async def _async_update(self, topic: str, payload: str, qos: int):
+        _LOGGER.info(f"HomieDevice._async_update: " + topic + ": " + payload)
         topic = topic.replace(self._prefix_topic, '')
 
         # Load Device Properties
@@ -289,6 +315,7 @@ class HomieNode(ChangeListener):
         self._type = STATE_UNKNOWN
 
     async def _async_setup(self, hass: HomeAssistantType, qos: int, properties_str: str):
+        _LOGGER.info(f"Homie Node _async_setup. properties: {properties_str}")
         for property_match in DISCOVER_PROPERTIES.finditer(properties_str):
             property_id = property_match.group('property_id')
             if property_id not in self._properties:
@@ -298,18 +325,32 @@ class HomieNode(ChangeListener):
                 self._properties[property_id] = property
                 await property._async_setup(hass, qos)
 
+        _LOGGER.info(f"________________QOS: {qos}")
         await mqtt.async_subscribe(hass, f'{self._prefix_topic}/#', self._async_update, qos)
 
 
     async def _async_update(self, topic: str, payload: str, qos: int):
+        _LOGGER.info(f"---Homie Node update.")
         topic = topic.replace(self._prefix_topic, '')
 
+        _LOGGER.info(f"Topic: " + topic)
+        _LOGGER.info(f"Payload: " + payload)
         if topic == '/$type': self._type = payload
         
+        # This is where to start. $/type doesn't seem to be sent, so the node 
+        # never calls _on_component_ready, which should finish it's setup. 
+        # Should look at Homie Convention 2.0.0, 2.0.1, as well as diff 
+        # between master and 2.0.0. Would also like to see if switch/voltage 
+        # send types. 
+        # Didn't see anything in between master and 2.0.0. Also didn't see 
+        # it mentioned in switch/voltage sending types. 
+        # Should look through MQTT logs to see if /$type is sent anywhere. 
         # Ready 
         if topic == '/$type' and not self._is_setup: 
             self._is_setup = True
             await self._on_component_ready(self)
+        # I suspect updating the node should happen here... Unless we want to 
+        # track the readings at the device level? 
 
     @property
     def base_topic(self):

--- a/homie.py
+++ b/homie.py
@@ -7,7 +7,7 @@ import datetime
 import voluptuous as vol
 import functools
 import homeassistant.components.mqtt as mqtt
-from homeassistant.components.mqtt import (CONF_DISCOVERY_PREFIX, CONF_QOS, valid_discovery_topic, _VALID_QOS_SCHEMA)
+from homeassistant.components.mqtt import (CONF_DISCOVERY_PREFIX, CONF_QOS, valid_subscribe_topic, _VALID_QOS_SCHEMA)
 from homeassistant.helpers.discovery import (async_load_platform)
 from homeassistant.helpers.event import (async_track_time_interval)
 from homeassistant.helpers import (config_validation as cv)
@@ -27,16 +27,16 @@ DOMAIN = 'homie'
 DEPENDENCIES = ['mqtt']
 INTERVAL_SECONDS = 1
 MESSAGE_MAX_KEEP_SECONDS = 5
-HOMIE_SUPPORTED_VERSION = '2.0.0'
+HOMIE_SUPPORTED_VERSION = '2.0.1'
 DEFAULT_DISCOVERY_PREFIX = 'homie'
-DEFAULT_QOS = 0
+DEFAULT_QOS = 1
 KEY_HOMIE_ALREADY_DISCOVERED = 'KEY_HOMIE_ALREADY_DISCOVERED'
 KEY_HOMIE_ENTITY_NAME = 'KEY_HOMIE_ENTITY_ID'
 
 # CONFIg
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_DISCOVERY_PREFIX, default=DEFAULT_DISCOVERY_PREFIX): valid_discovery_topic,
+        vol.Optional(CONF_DISCOVERY_PREFIX, default=DEFAULT_DISCOVERY_PREFIX): valid_subscribe_topic,
         vol.Optional(CONF_QOS, default=DEFAULT_QOS): _VALID_QOS_SCHEMA,
     }),
 }, extra=vol.ALLOW_EXTRA)

--- a/homie.py
+++ b/homie.py
@@ -74,64 +74,43 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
 
     # Sart
     async def async_start():
-        _LOGGER.info(f"Component - {DOMAIN} - Start. Discovery Topic: {discovery_prefix}/")
         await mqtt.async_subscribe(hass, f'{discovery_prefix}/+/$homie', async_discover_message_received, qos)
 
     async def async_discover_message_received(topic: str, payload: str, msg_qos: int):
-        _LOGGER.debug(f"Discover Message Received")
         device_match = DISCOVER_DEVICE.match(topic)
-        _LOGGER.debug(f"device_match: {device_match}")
-        _LOGGER.debug(f"payload: {payload}")
-        _LOGGER.debug(f"HOMIE_SUPPORTED_VERSION: {HOMIE_SUPPORTED_VERSION}")
 
         if device_match and payload == HOMIE_SUPPORTED_VERSION:
-            _LOGGER.debug(f"Found a device.")
             device_base_topic = device_match.group('prefix_topic')
             device_id = device_match.group('device_id')
             if device_id not in _DEVICES:
-                _LOGGER.debug(f"It's not in devices.")
                 device = HomieDevice(device_base_topic, device_id, async_component_ready)
                 _DEVICES[device_id] = device
                 await device._async_setup(hass, qos)
     
     async def async_component_ready(component):
-        # Start by investigating why it seems like this component isn't being setup. 
-        # Should be setting up both.
-        # Could it have something to do with the fact that we're actually using Homie 2.0.1
-        _LOGGER.info(f"component_ready: " + str(type(component)))
         if type(component) is HomieDevice:
-            _LOGGER.debug(f"Found Homie Device!")
             await async_setup_device(component)
-            _LOGGER.info(f"Finished async_setup_device.")
         if type(component) is HomieNode:
-            _LOGGER.info(f"Found Homie Node!")
             await async_setup_node(component)
 
     async def async_setup_device(device: HomieDevice):
-        _LOGGER.debug(f"setup_device")
         pass
 
     async def async_setup_node(node: HomieNode):
-        _LOGGER.info(f"setup_node: node.type: " + str(node.type))
         def get_entity_name():
             return f"{node.device.device_id}_{node.node_id}"
         if node.type == 'sensor':
-            _LOGGER.info(f"setup_node: Sensor")
             await setup_device_node_as_platform(get_entity_name(), node, 'sensor')
         elif node.type == 'switch':
-            _LOGGER.info(f"setup_node: Switch")
             await setup_device_node_as_platform(get_entity_name(), node, 'switch')
 
-
     async def setup_device_node_as_platform(entity_name: str, node: HomieNode, platform: str):
-        _LOGGER.info(f"device node as platform")
         hass.data[KEY_HOMIE_ALREADY_DISCOVERED][entity_name] = node
         discovery_info = {KEY_HOMIE_ENTITY_NAME: entity_name}
         await async_load_platform(hass, platform, DOMAIN, discovery_info)
 
     await async_start()
     return True
-
 
 # Types
 class ChangeListener(object):
@@ -150,7 +129,6 @@ class HomieDevice(ChangeListener):
     # A definition of a Homie Device
     def __init__(self, base_topic: str, device_id: str, on_component_ready):
         super().__init__()
-        _LOGGER.info(f"Homie Device Discovered. ID: {device_id}")
         self._nodes = dict()
         self._base_topic = base_topic
         self._device_id = device_id
@@ -173,17 +151,11 @@ class HomieDevice(ChangeListener):
         
     async def _async_setup(self, hass:HomeAssistantType, qos: int):
         async def async_discover_message_received(topic: str, payload: str, msg_qos: int):
-            _LOGGER.info(f"Property Discover mesage received")
             node_match = DISCOVER_NODES.match(topic)
-            _LOGGER.info(f"topic: " + topic)
-            _LOGGER.info(f"payload: " + payload)
-            _LOGGER.info(f"node_match: " + str(node_match))
             if node_match:
-                _LOGGER.info(f"The node_mached.")
                 node_base_topic = node_match.group('prefix_topic')
                 node_id = node_match.group('node_id')
                 if node_id not in self._nodes:
-                    _LOGGER.info(f"Not in self.nodes.")
                     node = HomieNode(self, node_base_topic, node_id, self._on_component_ready)
                     self._nodes[node_id] = node
                     await node._async_setup(hass, qos, payload)
@@ -192,7 +164,6 @@ class HomieDevice(ChangeListener):
         await mqtt.async_subscribe(hass, f'{self._prefix_topic}/#', self._async_update, qos)
 
     async def _async_update(self, topic: str, payload: str, qos: int):
-        _LOGGER.info(f"HomieDevice._async_update: " + topic + ": " + payload)
         topic = topic.replace(self._prefix_topic, '')
 
         # Load Device Properties
@@ -303,7 +274,6 @@ class HomieNode(ChangeListener):
     # A definition of a Homie Node
     def __init__(self, device: HomieDevice, base_topic: str, node_id: str, on_component_ready):
         super().__init__()
-        _LOGGER.info(f"Homie Node Discovered. ID: {node_id}")
         self._device = device
         self._properties = dict()
         self._base_topic = base_topic
@@ -315,7 +285,6 @@ class HomieNode(ChangeListener):
         self._type = STATE_UNKNOWN
 
     async def _async_setup(self, hass: HomeAssistantType, qos: int, properties_str: str):
-        _LOGGER.info(f"Homie Node _async_setup. properties: {properties_str}")
         for property_match in DISCOVER_PROPERTIES.finditer(properties_str):
             property_id = property_match.group('property_id')
             if property_id not in self._properties:
@@ -325,32 +294,18 @@ class HomieNode(ChangeListener):
                 self._properties[property_id] = property
                 await property._async_setup(hass, qos)
 
-        _LOGGER.info(f"________________QOS: {qos}")
         await mqtt.async_subscribe(hass, f'{self._prefix_topic}/#', self._async_update, qos)
 
 
     async def _async_update(self, topic: str, payload: str, qos: int):
-        _LOGGER.info(f"---Homie Node update.")
         topic = topic.replace(self._prefix_topic, '')
 
-        _LOGGER.info(f"Topic: " + topic)
-        _LOGGER.info(f"Payload: " + payload)
         if topic == '/$type': self._type = payload
         
-        # This is where to start. $/type doesn't seem to be sent, so the node 
-        # never calls _on_component_ready, which should finish it's setup. 
-        # Should look at Homie Convention 2.0.0, 2.0.1, as well as diff 
-        # between master and 2.0.0. Would also like to see if switch/voltage 
-        # send types. 
-        # Didn't see anything in between master and 2.0.0. Also didn't see 
-        # it mentioned in switch/voltage sending types. 
-        # Should look through MQTT logs to see if /$type is sent anywhere. 
         # Ready 
         if topic == '/$type' and not self._is_setup: 
             self._is_setup = True
             await self._on_component_ready(self)
-        # I suspect updating the node should happen here... Unless we want to 
-        # track the readings at the device level? 
 
     @property
     def base_topic(self):
@@ -395,7 +350,6 @@ class HomieProperty(ChangeListener):
     # A definition of a Homie Property
     def __init__(self, node: HomieNode, base_topic: str, property_id: str, settable: bool, ranges: tuple):
         super().__init__()
-        _LOGGER.info(f"Homie Property Discovered. ID: {property_id}")
         self._node = node
         self._base_topic = base_topic
         self._property_id = property_id
@@ -441,8 +395,6 @@ class HomieProperty(ChangeListener):
         """Return the Parent Node of the Property."""
         return self._node
 
-    ####
-
     @property
     def name(self):
         """Return the Name of the Property."""
@@ -463,5 +415,3 @@ class HomieProperty(ChangeListener):
         """Return the Format for the Property."""
         return self._format
     
-    
-

--- a/sensor/homie.py
+++ b/sensor/homie.py
@@ -18,12 +18,14 @@ def async_setup_platform(hass: HomeAssistantType, config: ConfigType, async_add_
     """Set up the Homie sensor."""
     _LOGGER.info(f"Setting up Homie Sensor: {config} - {discovery_info}")
 
+
     entity_name = discovery_info[KEY_HOMIE_ENTITY_NAME]
     homie_sensor_node = hass.data[KEY_HOMIE_ALREADY_DISCOVERED][entity_name]
+    _LOGGER.debug(f"homie_sensor_node (properties): " + str(homie_sensor_node.properties))
     if homie_sensor_node is None: 
-        raise ValueError("Homie Sensor faild to recive a Homie Node to bind too")
+        raise ValueError("Homie Sensor failed to recive a Homie Node to bind too")
     if not homie_sensor_node.has_property(VALUE_PROP): 
-        raise Exception(f"Homie Sensor Node doesnt have a {VALUE_PROP} property")
+        raise Exception(f"Homie Sensor Node doesn't have a {VALUE_PROP} property")
     
     async_add_entities([HomieSensor(entity_name, homie_sensor_node)])
 
@@ -34,6 +36,7 @@ class HomieSensor(Entity):
 
     def __init__(self, entity_name: str, homie_sensor_node: HomieNode):
         """Initialize Homie Sensor."""
+        _LOGGER.info(f"Init HomieSensor")
         self._name = entity_name
         self._node = homie_sensor_node
         self._node.device.add_listener(self._on_change)

--- a/sensor/homie.py
+++ b/sensor/homie.py
@@ -11,17 +11,12 @@ from homeassistant.helpers.typing import (HomeAssistantType, ConfigType)
 
 # CONSTANTS
 _LOGGER = logging.getLogger(__name__)
-VALUE_PROP = 'value'
 
 @asyncio.coroutine
 def async_setup_platform(hass: HomeAssistantType, config: ConfigType, async_add_entities, discovery_info=None):
     """Set up the Homie sensor."""
-    _LOGGER.info(f"Setting up Homie Sensor: {config} - {discovery_info}")
-
-
     entity_name = discovery_info[KEY_HOMIE_ENTITY_NAME]
     homie_sensor_node = hass.data[KEY_HOMIE_ALREADY_DISCOVERED][entity_name]
-    _LOGGER.debug(f"homie_sensor_node (properties): " + str(homie_sensor_node.properties))
     if homie_sensor_node is None: 
         raise ValueError("Homie Sensor failed to recive a Homie Node to bind too")
     if not homie_sensor_node.has_property(VALUE_PROP): 
@@ -36,7 +31,6 @@ class HomieSensor(Entity):
 
     def __init__(self, entity_name: str, homie_sensor_node: HomieNode):
         """Initialize Homie Sensor."""
-        _LOGGER.info(f"Init HomieSensor")
         self._name = entity_name
         self._node = homie_sensor_node
         self._node.device.add_listener(self._on_change)

--- a/temp/discovery.py
+++ b/temp/discovery.py
@@ -46,7 +46,7 @@ def async_start(hass, discovery_topic, hass_config):
     @asyncio.coroutine
     def async_device_message_received(topic, payload, qos):
         """Process the received message."""
-        #_LOGGER.warning("mqdiscover | [%s]:[%s]:[%s]", qos, topic, payload)
+        _LOGGER.info("mqdiscover | [%s]:[%s]:[%s]", qos, topic, payload)
         
         # List of all topics published on MQTT since HA was started
         messages[topic] = payload
@@ -61,9 +61,9 @@ def async_start(hass, discovery_topic, hass_config):
                 nodelist[b[0]] = b[1]
             device = match_nodes.group('device')
             nodes[device] = nodelist
-            #for key, val in nodes.items():
-                #for key2, val2 in val.items():
-                    #_LOGGER.warning("Device:[%s] - Node:[%s] - Type:[%s]", key, key2, val2)
+            for key, val in nodes.items():
+                for key2, val2 in val.items():
+                    _LOGGER.warning("Device:[%s] - Node:[%s] - Type:[%s]", key, key2, val2)
         
         # Check if topic is $online topic
         match_online = TOPIC_ONLINE.match(topic)


### PR DESCRIPTION
I took the work Tim did on the HA_Homie component (nerdfirefighter/HA_Homie/tree/dev), and refactored it to better support sensors of different types. Instead of using the value property, I have it ignore properties that start with "_", "$" and "unit", and if there is only one left, the node uses that as the value to display within Home Assistant.

There are a couple issues, so I'm not sure if this is the best approach. But it works for my set up well, so I'm using it as a starting point.

The first issue is that it seems like the Homie convention (homieiot/convention) says that each physical sensor should be a node that advertises all of its readings as properties. So a DHT22 would have a temperate property AND a humidity property. The issue is that when this node is set up in Home Assistant, it now has 2 properties, but can only display one. So instead, I made a node for DHT22-Temperature and DHT22-Humidity.

The second issue is that all the code I've working with makes it seem like the sensors should be posting their readings to the value property rather than degree/relative that I've been using. I looked through the Homie Convention, but couldn't find anything talking about a value property. Using value makes it easy to pick which channel to use, but it seems less descriptive than what I'm using. It also doesn't support multiple properties very well. Perhaps a better way of doing it would be to send out what property to follow using a main_property property? I figure I'll have a better idea of which way to go once I've added more sensors.